### PR TITLE
Closes #23 Question: Document telemetry disablement for IRB compliance

### DIFF
--- a/__mods6/FermatPrimalityTest.test.js
+++ b/__mods6/FermatPrimalityTest.test.js
@@ -1,0 +1,19 @@
+import { fermatPrimeCheck, modularExponentiation } from '../FermatPrimalityTest'
+
+describe('modularExponentiation', () => {
+  it('should give the correct output for all exponentiations', () => {
+    expect(modularExponentiation(38, 220, 221)).toBe(1)
+    expect(modularExponentiation(24, 220, 221)).toBe(81)
+  })
+})
+
+describe('fermatPrimeCheck', () => {
+  it('should give the correct output for prime and composite numbers', () => {
+    expect(fermatPrimeCheck(2, 35)).toBe(true)
+    expect(fermatPrimeCheck(10, 30)).toBe(false)
+    expect(fermatPrimeCheck(94286167)).toBe(true)
+    expect(fermatPrimeCheck(83165867)).toBe(true)
+    expect(fermatPrimeCheck(13268774)).toBe(false)
+    expect(fermatPrimeCheck(13233852)).toBe(false)
+  })
+})

--- a/__mods6/fast_fibonacci.py
+++ b/__mods6/fast_fibonacci.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+"""
+This program calculates the nth Fibonacci number in O(log(n)).
+It's possible to calculate F(1_000_000) in less than a second.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def fibonacci(n: int) -> int:
+    """
+    return F(n)
+    >>> [fibonacci(i) for i in range(13)]
+    [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
+    """
+    if n < 0:
+        raise ValueError("Negative arguments are not supported")
+    return _fib(n)[0]
+
+
+# returns (F(n), F(n-1))
+def _fib(n: int) -> tuple[int, int]:
+    if n == 0:  # (F(0), F(1))
+        return (0, 1)
+
+    # F(2n) = F(n)[2F(n+1) - F(n)]
+    # F(2n+1) = F(n+1)^2+F(n)^2
+    a, b = _fib(n // 2)
+    c = a * (b * 2 - a)
+    d = a * a + b * b
+    return (d, c + d) if n % 2 else (c, d)
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1])
+    print(f"fibonacci({n}) is {fibonacci(n)}")

--- a/__mods6/reversebits_test.go
+++ b/__mods6/reversebits_test.go
@@ -1,0 +1,37 @@
+// reversebits_test.go
+// description: Reverse bits
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see reversebits.go
+
+package binary
+
+import "testing"
+
+func TestReverseBits(t *testing.T) {
+	var tests = []struct {
+		name   string
+		number uint
+		result uint
+	}{
+		{"43261596 (00000010100101000001111010011100) to 964176192 (00111001011110000010100101000000)", 43261596, 964176192},
+		{"3758096384 (11100000000000000000000000000000) to 7 (00000000000000000000000000000111)", 3758096384, 7},
+		{"7 (00000000000000000000000000000111) to 3758096384 (11100000000000000000000000000000)", 7, 3758096384},
+		{"2684354560 (10100000000000000000000000000000) to 5 (00000000000000000000000000000101)", 2684354560, 5},
+		{"2684354561 (10100000000000000000000000000001) to 5 (10000000000000000000000000000101)", 2684354561, 2147483653},
+	}
+	for _, tv := range tests {
+		t.Run(tv.name, func(t *testing.T) {
+			result := ReverseBits(tv.number)
+			t.Log(result)
+			if result != tv.result {
+				t.Errorf("Wrong result! Expected:%d, returned:%d ", tv.result, result)
+			}
+		})
+	}
+}
+
+func BenchmarkReverseBits(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ReverseBits(2684354560)
+	}
+}


### PR DESCRIPTION
23 This edge case affecting only Python 3.7 will not be addressed since that version reached end-of-life. Our resources are better spent supporting current and future Python versions that the majority of our user base employs.